### PR TITLE
Add argument for setting the testDeviceId when requesting consent info

### DIFF
--- a/lib/flutter_funding_choices.dart
+++ b/lib/flutter_funding_choices.dart
@@ -10,11 +10,19 @@ class FlutterFundingChoices {
       const MethodChannel('flutter_funding_choices');
 
   /// Allows to get the current consent information.
+  ///
+  /// [testDeviceId] Device id to use when testing in order to force geography to the EEA
   static Future<ConsentInformation> requestConsentInformation(
-      {bool tagForUnderAgeOfConsent = false}) async {
-    Map<String, dynamic> result = Map<String, dynamic>.from(await _channel
-        .invokeMethod('requestConsentInformation',
-            {'tagForUnderAgeOfConsent': tagForUnderAgeOfConsent}));
+      {bool tagForUnderAgeOfConsent = false, String testDeviceId = ""}) async {
+    Map<String, dynamic> result = Map<String, dynamic>.from(
+      await _channel.invokeMethod(
+        'requestConsentInformation',
+        {
+          'tagForUnderAgeOfConsent': tagForUnderAgeOfConsent,
+          'testDeviceId': testDeviceId
+        },
+      ),
+    );
     return ConsentInformation(
       consentStatus: result['consentStatus'],
       consentType: result['consentType'],


### PR DESCRIPTION
Can now show consent form when testing outside of the EEA